### PR TITLE
feat:add RSSHub RSSHubAccessKey

### DIFF
--- a/docs/config-zh.md
+++ b/docs/config-zh.md
@@ -59,6 +59,7 @@
 | `scrape.past`            | `time.Duration` | 抓取 Feed 的回溯时间窗口。例如 `1h` 表示只抓取过去 1 小时的 Feed。                                                                                     | `24h`  | 否                                  |
 | `scrape.interval`        | `time.Duration` | 抓取每个源的频率 (全局默认值)。例如 `1h`。                                                                                                             | `1h`   | 否                                  |
 | `scrape.rsshub_endpoint` | `string`        | RSSHub 的端点。你可以部署自己的 RSSHub 服务器或使用公共实例 (参见 [RSSHub 文档](https://docs.rsshub.app/guide/instances))。例如 `https://rsshub.app`。 |        | 是 (如果使用了 `rsshub_route_path`) |
+| `scrape.rsshub_access_key`  | `string`        | RSSHub 的访问密钥。用于访问控制。(详情见 [RSSHub文档访问控制](https://docs.rsshub.app/deploy/config#access-control-configurations)) |        | 否 |
 | `scrape.sources`         | `对象列表`      | 用于抓取 Feed 的源列表。详见下方的 **抓取源配置**。                                                                                                    | `[]`   | 是 (至少一个)                       |
 
 ### 抓取源配置 (`scrape.sources[]`)

--- a/docs/config.md
+++ b/docs/config.md
@@ -59,6 +59,7 @@ This section configures parameters related to the Jina AI Reader API, primarily 
 | `scrape.past`            | `time.Duration`   | Time window to look back when scraping feeds. E.g., `1h` means only scrape feeds from the past 1 hour.                                                                                 | `24h`         | No                                   |
 | `scrape.interval`        | `time.Duration`   | Frequency to scrape each source (global default). E.g., `1h`.                                                                                                                          | `1h`          | No                                   |
 | `scrape.rsshub_endpoint` | `string`          | Endpoint for RSSHub. You can deploy your own RSSHub server or use a public instance (see [RSSHub Documentation](https://docs.rsshub.app/guide/instances)). E.g., `https://rsshub.app`. |               | Yes (if `rsshub_route_path` is used) |
+| `scrape.rsshub_access_key`  | `string` | The access key for RSSHub. Used for access control. (see [RSSHub config](https://docs.rsshub.app/deploy/config#access-control-configurations))| | No |
 | `scrape.sources`         | `list of objects` | List of sources to scrape feeds from. See **Scrape Source Configuration** below.                                                                                                       | `[]`          | Yes (at least one)                   |
 
 ### Scrape Source Configuration (`scrape.sources[]`)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,7 +134,6 @@ type ScrapeSource struct {
 type ScrapeSourceRSS struct {
 	URL             string `yaml:"url,omitempty" json:"url,omitempty" desc:"The URL of the RSS feed. e.g. http://localhost:1200/github/trending/daily/any. You can not set it when rsshub_route_path is set."`
 	RSSHubRoutePath string `yaml:"rsshub_route_path,omitempty" json:"rsshub_route_path,omitempty" desc:"The RSSHub route path of the RSS feed. e.g. github/trending/daily/any. It will be joined with the rsshub_endpoint as the final URL."`
-	// RSSHubAccessKey string `yaml:"rsshub_access_key,omitempty" json:"rsshub_access_key,omitempty" desc:"The access key for accessing RSSHub routes. If set, it will be appended as a query parameter to the URL."`
 }
 
 type RewriteRule struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,10 +95,11 @@ type LLM struct {
 }
 
 type Scrape struct {
-	Past           timeutil.Duration `yaml:"past,omitempty" json:"past,omitempty" desc:"The lookback time window for scraping feeds. e.g. 1h means only scrape feeds in the past 1 hour. Default: 3d"`
-	Interval       timeutil.Duration `yaml:"interval,omitempty" json:"interval,omitempty" desc:"How often to scrape each source, it is a global interval. e.g. 1h. Default: 1h"`
-	RSSHubEndpoint string            `yaml:"rsshub_endpoint,omitempty" json:"rsshub_endpoint,omitempty" desc:"The endpoint of the RSSHub. You can deploy your own RSSHub server or use the public one (https://docs.rsshub.app/guide/instances). e.g. https://rsshub.app. It is required when sources[].rss.rsshub_route_path is set."`
-	Sources        []ScrapeSource    `yaml:"sources,omitempty" json:"sources,omitempty" desc:"The sources for scraping feeds."`
+	Past            timeutil.Duration `yaml:"past,omitempty" json:"past,omitempty" desc:"The lookback time window for scraping feeds. e.g. 1h means only scrape feeds in the past 1 hour. Default: 3d"`
+	Interval        timeutil.Duration `yaml:"interval,omitempty" json:"interval,omitempty" desc:"How often to scrape each source, it is a global interval. e.g. 1h. Default: 1h"`
+	RSSHubEndpoint  string            `yaml:"rsshub_endpoint,omitempty" json:"rsshub_endpoint,omitempty" desc:"The endpoint of the RSSHub. You can deploy your own RSSHub server or use the public one (https://docs.rsshub.app/guide/instances). e.g. https://rsshub.app. It is required when sources[].rss.rsshub_route_path is set."`
+	RSSHubAccessKey string            `yaml:"rsshub_access_key,omitempty" json:"rsshub_access_key,omitempty" desc:"The access key for RSSHub. Used for access control. (see [RSSHub config](https://docs.rsshub.app/deploy/config#access-control-configurations))"`
+	Sources         []ScrapeSource    `yaml:"sources,omitempty" json:"sources,omitempty" desc:"The sources for scraping feeds."`
 }
 
 type Storage struct {
@@ -133,6 +134,7 @@ type ScrapeSource struct {
 type ScrapeSourceRSS struct {
 	URL             string `yaml:"url,omitempty" json:"url,omitempty" desc:"The URL of the RSS feed. e.g. http://localhost:1200/github/trending/daily/any. You can not set it when rsshub_route_path is set."`
 	RSSHubRoutePath string `yaml:"rsshub_route_path,omitempty" json:"rsshub_route_path,omitempty" desc:"The RSSHub route path of the RSS feed. e.g. github/trending/daily/any. It will be joined with the rsshub_endpoint as the final URL."`
+	// RSSHubAccessKey string `yaml:"rsshub_access_key,omitempty" json:"rsshub_access_key,omitempty" desc:"The access key for accessing RSSHub routes. If set, it will be appended as a query parameter to the URL."`
 }
 
 type RewriteRule struct {

--- a/pkg/scrape/manager.go
+++ b/pkg/scrape/manager.go
@@ -80,6 +80,7 @@ func (c *Config) From(app *config.App) {
 				URL:             app.Scrape.Sources[i].RSS.URL,
 				RSSHubEndpoint:  app.Scrape.RSSHubEndpoint,
 				RSSHubRoutePath: app.Scrape.Sources[i].RSS.RSSHubRoutePath,
+				RSSHubAccessKey: app.Scrape.RSSHubAccessKey,
 			}
 		}
 	}

--- a/pkg/scrape/scraper/rss.go
+++ b/pkg/scrape/scraper/rss.go
@@ -33,6 +33,7 @@ type ScrapeSourceRSS struct {
 	URL             string
 	RSSHubEndpoint  string
 	RSSHubRoutePath string
+	RSSHubAccessKey string
 }
 
 func (c *ScrapeSourceRSS) Validate() error {
@@ -44,6 +45,15 @@ func (c *ScrapeSourceRSS) Validate() error {
 	}
 	if c.URL != "" && !strings.HasPrefix(c.URL, "http://") && !strings.HasPrefix(c.URL, "https://") {
 		return errors.New("URL must be a valid HTTP/HTTPS URL")
+	}
+
+	// Append access key as query parameter if provided
+	if c.RSSHubAccessKey != "" && !strings.Contains(c.URL, "key=") {
+		if strings.Contains(c.URL, "?") {
+			c.URL += "&key=" + c.RSSHubAccessKey
+		} else {
+			c.URL += "?key=" + c.RSSHubAccessKey
+		}
 	}
 
 	return nil

--- a/pkg/scrape/scraper/rss.go
+++ b/pkg/scrape/scraper/rss.go
@@ -48,7 +48,7 @@ func (c *ScrapeSourceRSS) Validate() error {
 	}
 
 	// Append access key as query parameter if provided
-	if c.RSSHubAccessKey != "" && !strings.Contains(c.URL, "key=") {
+	if c.RSSHubEndpoint != "" && c.RSSHubAccessKey != "" && !strings.Contains(c.URL, "key=") {
 		if strings.Contains(c.URL, "?") {
 			c.URL += "&key=" + c.RSSHubAccessKey
 		} else {

--- a/pkg/scrape/scraper/rss.go
+++ b/pkg/scrape/scraper/rss.go
@@ -48,6 +48,12 @@ func (c *ScrapeSourceRSS) Validate() error {
 	}
 
 	// Append access key as query parameter if provided
+	c.appendAccessKey()
+
+	return nil
+}
+
+func (c *ScrapeSourceRSS) appendAccessKey() {
 	if c.RSSHubEndpoint != "" && c.RSSHubAccessKey != "" && !strings.Contains(c.URL, "key=") {
 		if strings.Contains(c.URL, "?") {
 			c.URL += "&key=" + c.RSSHubAccessKey
@@ -55,8 +61,6 @@ func (c *ScrapeSourceRSS) Validate() error {
 			c.URL += "?key=" + c.RSSHubAccessKey
 		}
 	}
-
-	return nil
 }
 
 // --- Factory code block ---

--- a/pkg/scrape/scraper/rss_test.go
+++ b/pkg/scrape/scraper/rss_test.go
@@ -166,7 +166,7 @@ func TestNewRSS(t *testing.T) {
 					Expect(r).NotTo(BeNil())
 					rssReader, ok := r.(*rssReader)
 					Expect(ok).To(BeTrue())
-					Expect(rssReader.config.URL).To(Equal("http://example.com/feed?key=testkey"))
+					Expect(rssReader.config.URL).To(Equal("http://example.com/feed"))
 					Expect(rssReader.config.RSSHubAccessKey).To(Equal("testkey"))
 				},
 			},

--- a/pkg/scrape/scraper/rss_test.go
+++ b/pkg/scrape/scraper/rss_test.go
@@ -122,6 +122,55 @@ func TestNewRSS(t *testing.T) {
 				},
 			},
 		},
+		{
+			Scenario: "Valid Configuration - RSSHub with Access Key",
+			Given:    "a valid configuration with RSSHub details and access key",
+			When:     "creating a new RSS reader",
+			Then:     "should succeed, construct the URL with access key, and return a valid reader",
+			GivenDetail: givenDetail{
+				config: &ScrapeSourceRSS{
+					RSSHubEndpoint:  "http://rsshub.app/",
+					RSSHubRoutePath: "/_/test",
+					RSSHubAccessKey: "testkey",
+				},
+			},
+			WhenDetail: whenDetail{},
+			ThenExpected: thenExpected{
+				wantErr: false,
+				validateFunc: func(t *testing.T, r reader) {
+					Expect(r).NotTo(BeNil())
+					rssReader, ok := r.(*rssReader)
+					Expect(ok).To(BeTrue())
+					Expect(rssReader.config.URL).To(Equal("http://rsshub.app/_/test?key=testkey"))
+					Expect(rssReader.config.RSSHubEndpoint).To(Equal("http://rsshub.app/"))
+					Expect(rssReader.config.RSSHubRoutePath).To(Equal("/_/test"))
+					Expect(rssReader.config.RSSHubAccessKey).To(Equal("testkey"))
+				},
+			},
+		},
+		{
+			Scenario: "Valid Configuration - URL with Access Key",
+			Given:    "a valid configuration with URL and access key",
+			When:     "creating a new RSS reader",
+			Then:     "should succeed, append access key to URL, and return a valid reader",
+			GivenDetail: givenDetail{
+				config: &ScrapeSourceRSS{
+					URL:             "http://example.com/feed",
+					RSSHubAccessKey: "testkey",
+				},
+			},
+			WhenDetail: whenDetail{},
+			ThenExpected: thenExpected{
+				wantErr: false,
+				validateFunc: func(t *testing.T, r reader) {
+					Expect(r).NotTo(BeNil())
+					rssReader, ok := r.(*rssReader)
+					Expect(ok).To(BeTrue())
+					Expect(rssReader.config.URL).To(Equal("http://example.com/feed?key=testkey"))
+					Expect(rssReader.config.RSSHubAccessKey).To(Equal("testkey"))
+				},
+			},
+		},
 	}
 
 	// --- Run tests ---


### PR DESCRIPTION
本次更新新增了对 RSSHub 访问密钥（AccessKey）的配置支持。该配置项的主要作用是：当 RSSHub 服务启用了基于访问密钥的访问控制机制时，用户可通过配置该密钥实现授权访问。此功能特别适用于 ZenFeed 与 RSSHub 服务部署在不同服务器上的场景，能够有效提升跨服务访问的安全性与便捷性。

----

This update introduces support for configuring the RSSHub AccessKey. The primary purpose of this configuration is to enable authorized access to RSSHub when it has access control enabled via an AccessKey. This feature is particularly useful in scenarios where ZenFeed and RSSHub are deployed on different servers, enhancing both security and convenience for cross-service access.

## Sourcery 摘要

通过扩展配置模式、更新抓取器逻辑以将密钥附加到 URL，并添加相应的文档和测试，引入对 RSSHub 访问密钥的支持。

新功能:
- 添加 RSSHubAccessKey 配置以启用对 RSSHub 的授权访问

改进:
- 在构建 RSS feed URL 时，将提供的访问密钥作为查询参数附加
- 将全局 RSSHubAccessKey 设置传播到每个 RSS 抓取源

文档:
- 在英文和中文配置文件中记录 scrape.rsshub_access_key 字段

测试:
- 添加单元测试以验证使用 RSSHub 访问密钥的 URL 构建，针对 RSSHub 端点和直接 feed URL

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce support for an RSSHub access key by extending the config schema, updating the scraper logic to append the key to URLs, and adding corresponding documentation and tests

New Features:
- Add RSSHubAccessKey configuration to enable authorized access to RSSHub

Enhancements:
- Append the provided access key as a query parameter when constructing RSS feed URLs
- Propagate the global RSSHubAccessKey setting into each RSS scrape source

Documentation:
- Document the scrape.rsshub_access_key field in both English and Chinese configuration files

Tests:
- Add unit tests to verify URL construction with the RSSHub access key for both RSSHub endpoints and direct feed URLs

</details>